### PR TITLE
タグの取得

### DIFF
--- a/lib/NotionAPI.ts
+++ b/lib/NotionAPI.ts
@@ -18,11 +18,19 @@ export const getAllPost = async () => {
 };
 
 const getPageMetaData = (post) => {
+  const getTags = (tags) => {
+    const allTags = tags.map((tag) => {
+      return tag.name;
+    });
+    return allTags;
+  };
+
   return {
     id: post.id,
     title: post.properties.Name.title[0].plain_text,
     description: post.properties.Description.rich_text[0].plain_text,
     date: post.properties.Date.date.start,
     slug: post.properties.Slug.rich_text[0].plain_text,
+    tags: getTags(post.properties.Tags.multi_select),
   };
 };


### PR DESCRIPTION
APIからの取得方法は大事。APIで配列の形式になっていた場合は、map関数を使う
